### PR TITLE
Use compile instead of ansi-term

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,20 +6,6 @@ Add `npm-mode-npm-run-debug` command that will run a project script
 under the node debugger, and bind it to <kbd>C-c n d</kbd> in mode
 command keymap.
 
-### Improve handling of exec buffers ###
-
-At conclusion of running any npm command, the user is left in a
-terminal buffer with a process attached. This requires the user to
-<kbd>C-x k</kbd><kbd>y</kbd> to dispose of.
-
-To the user, the fact that it ran in an ansi-term is irrelevant, and
-being left it one at conclusion of operation is annoying. Rather than
-presenting the user with a terminal buffer at all, why not just hook
-up the buffer to the npm command's i/o streams. When the command ends,
-we could then just display a status message and a `Press q to quit...`
-message. When the user hits <kbd>q</kbd> the buffer would then be
-killed leaving the user in the buffer they started in.
-
 ### Add ability to specialize command invocation in keymap.
 
 Some commands, like `npm install --depth=0`, provide options to alter

--- a/npm-mode.el
+++ b/npm-mode.el
@@ -55,9 +55,6 @@
 (defvar npm-mode--project-file-name "package.json"
   "The name of npm project files.")
 
-(defvar npm-mode--buffer-name "*npm-mode*"
-  "Name of npm mode buffers.")
-
 (defvar npm-mode--modeline-name " npm"
   "Name of npm mode modeline name.")
 
@@ -89,51 +86,48 @@ nil."
   "Get a list of project dependencies."
   (npm-mode--get-project-property "dependencies"))
 
-(defun npm-mode--exec-process (process cmd)
-  "Execute a PROCESS running CMD."
-  (let ((name (concat "*" process "*"))
-        (cmd-line (concat cmd "\n" )))
-    (message (concat "Running " cmd-line))
-    (ansi-term (getenv "SHELL") process)
-    (comint-send-string name cmd-line)))
+(defun npm-mode--exec-process (cmd)
+  "Execute a process running CMD."
+  (message (concat "Running " cmd))
+  (compile cmd))
 
 (defun npm-mode-npm-init ()
   "Run the npm init command."
   (interactive)
-  (npm-mode--exec-process "npm-init" "npm init"))
+  (npm-mode--exec-process "npm init"))
 
 (defun npm-mode-npm-install ()
   "Run the 'npm install' command."
   (interactive)
-  (npm-mode--exec-process "npm-install" "npm install"))
+  (npm-mode--exec-process "npm install"))
 
 (defun npm-mode-npm-install-save (dep)
   "Run the 'npm install --save' command for DEP."
   (interactive "sEnter package name: ")
-  (npm-mode--exec-process "npm-install-save" (format "npm install %s --save" dep)))
+  (npm-mode--exec-process (format "npm install %s --save" dep)))
 
 (defun npm-mode-npm-install-save-dev (dep)
   "Run the 'npm install --save-dev' command for DEP."
   (interactive "sEnter package name: ")
-  (npm-mode--exec-process "npm-install-save" (format "npm install %s --save-dev" dep)))
+  (npm-mode--exec-process (format "npm install %s --save-dev" dep)))
 
 (defun npm-mode-npm-uninstall ()
   "Run the 'npm uninstall' command."
   (interactive)
   (let ((dep (completing-read "Uninstall dependency: " (npm-mode--get-project-dependencies))))
-    (npm-mode--exec-process "npm-uninstall" (format "npm uninstall %s" dep))))
-  
+    (npm-mode--exec-process (format "npm uninstall %s" dep))))
+
 (defun npm-mode-npm-list ()
   "Run the 'npm list' command."
   (interactive)
-  (npm-mode--exec-process "npm-list" "npm list --depth=0"))
+  (npm-mode--exec-process "npm list --depth=0"))
 
 (defun npm-mode-npm-run ()
   "Run the 'npm run' command on a project script."
   (interactive)
   (let ((script (completing-read "Run script: " (npm-mode--get-project-scripts))))
-    (npm-mode--exec-process "npm-run" (format "npm run %s" script))))
-  
+    (npm-mode--exec-process (format "npm run %s" script))))
+
 (defun npm-mode-visit-project-file ()
   "Visit the project file."
   (interactive)


### PR DESCRIPTION
Compile is great for executing individual commands like this since you can restart a process with `g` and kill the buffer with `q`. While this does still display the buffer, it allows the user to read any error messages from npm commands (especially important since you might be running a test script with useful output), and compilation mode will try to highlight file locations to provide shortcuts for opening them in buffers.

Note that this doesn't rename the buffer like your code did previously. This is possible by manually renaming compilation buffers, but I feel it may not be necessary since you'd likely only have one compilation process running at once.