### PR TITLE
Fix use of non-standard function mistakenly used

### DIFF
--- a/npm-mode.el
+++ b/npm-mode.el
@@ -84,9 +84,10 @@ nil."
          (commands (list)))
     (cond ((hash-table-p value)
            (maphash (lambda (key value)
-                      (append-to-list
-                       commands
-                       (list (list key (format "%s %s" "npm" key)))))
+                      (setq commands
+                            (append commands
+                                    (list (list key (format "%s %s" "npm" key))))
+                            ))
                     value)
            commands)
           (t value))))


### PR DESCRIPTION
😐 That pull request I posted used a function from another package. Put back code that only uses standard elisp.